### PR TITLE
Fix mkldnn int8 inference config settings doc

### DIFF
--- a/c++/x86_linux_demo/model_test.cc
+++ b/c++/x86_linux_demo/model_test.cc
@@ -28,7 +28,6 @@ int main(int argc, char *argv[]) {
   config.EnableMKLDNN();
   config.SetCpuMathLibraryNumThreads(FLAGS_threads);
   config.SwitchIrOptim();
-  config.EnableMemoryOptim();
   
   // Create predictor
   auto predictor = paddle_infer::CreatePredictor(config);

--- a/docs/optimize/paddle_x86_cpu_int8.md
+++ b/docs/optimize/paddle_x86_cpu_int8.md
@@ -164,8 +164,7 @@ else:
     config = Config(args.model_dir)
 config.enable_mkldnn()
 config.set_cpu_math_library_num_threads(args.threads)
-config.switch_ir_optim(False)
-config.enable_memory_optim()
+config.switch_ir_optim()
 
 predictor = create_predictor(config)
 ```

--- a/docs/optimize/paddle_x86_cpu_int8.md
+++ b/docs/optimize/paddle_x86_cpu_int8.md
@@ -149,9 +149,8 @@ config.SetModel(FLAGS_model_file, FLAGS_params_file); // Load combined model
 config.SetModel(FLAGS_model_dir); // Load no-combined model
 }
 config.EnableMKLDNN();
-config.SwitchIrOptim(false);
+config.SwitchIrOptim(true);
 config.SetCpuMathLibraryNumThreads(FLAGS_threads);
-config.EnableMemoryOptim();
 
 auto predictor = paddle_infer::CreatePredictor(config);
 ```


### PR DESCRIPTION
- Inference for MKLDNN INT8 model should set `config.SwitchIrOptim(true)` or `config.SwitchIrOptim()`, and no need to set `config.EnableMemoryOptim();`, because memory_optim_pass will never be added when mkldnn ON anyway. 
- Refer to https://github.com/PaddlePaddle/Paddle/pull/37225