### PR TITLE
设置文档主题选项，让目录折叠展示

### DIFF
--- a/docs-official/conf.py
+++ b/docs-official/conf.py
@@ -77,6 +77,10 @@ pygments_style = None
 #
 html_theme = 'sphinx_rtd_theme'
 
+html_theme_options = {
+    'collapse_navigation': False,
+}
+
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the
 # documentation.


### PR DESCRIPTION
修改sphinx的配置文件 config.py，添加主题选项：collapse_navigation = false