### PR TITLE
Update cuda version information

### DIFF
--- a/docs-official/guides/install/python_install.md
+++ b/docs-official/guides/install/python_install.md
@@ -4,11 +4,8 @@
 
 ## 环境准备
 
-- Python: 3.6 / 3.7 / 3.8 / 3.9
 - Python: 3.6 / 3.7 / 3.8 / 3.9 / 3.10
-- CUDA 10.1 / CUDA 10.2 / CUDA 11.1 / CUDA 11.2 / CUDA 11.6 / CUDA 11.7, cuDNN7.6+, TensorRT （仅在使用 GPU 版本的推理库时需要）
-
-您可参考 NVIDIA 官方文档了解 CUDA 和 cuDNN 的安装流程和配置方法，请见 [CUDA](https://docs.nvidia.com/cuda/cuda-installation-guide-linux/)，[cuDNN](https://docs.nvidia.com/deeplearning/sdk/cudnn-install/)，版本对应关系如下表所示：
+- CUDA 10.2 / CUDA 11.2 / CUDA 11.6 / CUDA 11.7, cuDNN7.6+, TensorRT （仅在使用 GPU 版本的推理库时需要）
 
 您可参考 NVIDIA 官方文档了解 CUDA、cuDNN 和 TensorRT 的安装流程和配置方法，请见 [CUDA](https://docs.nvidia.com/cuda/cuda-installation-guide-linux/)，[cuDNN](https://docs.nvidia.com/deeplearning/sdk/cudnn-install/)，[TensorRT](https://developer.nvidia.com/tensorrt)
 
@@ -17,10 +14,7 @@ Linux 下，版本对应关系如下表所示：
 
 |CUDA 版本|cuDNN 版本| TensorRT 版本|
 |---|---|---|
-|10.1|7.6.5||
 |10.2|7.6.5|7.0.0.11|
-|11.1|8.1.1|7.2.3.4|
-|11.2|8.1.1|8.0.3.4|
 |11.2|8.2.1|8.0.3.4|
 |11.6|8.4.0|8.4.0.6|
 |11.7|8.4.1|8.4.2.4|
@@ -29,9 +23,7 @@ Windows 下，版本对应关系如下表所示：
 
 |CUDA 版本|cuDNN 版本| TensorRT 版本|
 |---|---|---|
-|10.1|7.6.5||
 |10.2|7.6.5|7.0.0.11|
-|11.1|8.1.1|8.0.3.4|
 |11.2|8.2.1|8.2.4.2|
 |11.6|8.4.0|8.4.0.6|
 |11.7|8.4.1|8.4.2.4|
@@ -42,13 +34,7 @@ Windows 下，版本对应关系如下表所示：
 
 参考[Pip 安装](https://www.paddlepaddle.org.cn/documentation/docs/zh/2.4rc/install/pip/frompip.html)
 
-### 方式二：下载 whl 包（可选 TensorRT）到本地，然后通过 pip 工具安装
-
-[下载安装 Linux Python installer](download_lib.html#python)
-
-Linux 下仅提供 CUDA11.2/cuDNN8.2.1/TensorRT8.0.3.4 版本组合的 whl 包，其他组合请使用方式一(pip 在线安装)
-
-### 方式三：源码安装
+### 方式二：源码安装
 
 参考[源码编译](./compile/index_compile.html)文档。
 

--- a/docs-official/guides/install/python_install.md
+++ b/docs-official/guides/install/python_install.md
@@ -32,7 +32,7 @@ Windows 下，版本对应关系如下表所示：
 
 ### 方式一：通过 pip 在线安装（包含 TensorRT）
 
-参考[Pip 安装](https://www.paddlepaddle.org.cn/documentation/docs/zh/2.4rc/install/pip/frompip.html)
+参考[Pip 安装](https://www.paddlepaddle.org.cn/documentation/docs/zh/2.4/install/pip/frompip.html)
 
 ### 方式二：源码安装
 


### PR DESCRIPTION
更新 cuda 版本信息：
1. 2.4 版本不再发布 cuda10.1 与 cuda11.1 的 Paddle 包
2. 2.4 版本 cuda11.2 对应的 cudnn 版本统一为 8.2.1。直接 pip 安装，不再需要额外下载 whl 包