### PR TITLE
fix ernie test for varlen

### DIFF
--- a/c++/gpu/ernie-varlen/ernie_varlen_test.cc
+++ b/c++/gpu/ernie-varlen/ernie_varlen_test.cc
@@ -65,8 +65,13 @@ std::shared_ptr<Predictor> InitPredictor() {
   // erinie varlen must be used with dynamic shape
   config.SetTRTDynamicShapeInfo(min_input_shape, max_input_shape,
                                 opt_input_shape);
+
   // erinie varlen must be used with oss
-  config.EnableTensorRtOSS();
+  config.EnableVarseqlen();
+  paddle_infer::experimental::InternalUtils::SetTransformerPosid(&config,
+                                                                 input_name2);
+  paddle_infer::experimental::InternalUtils::SetTransformerMaskid(&config,
+                                                                  input_name3);
 
   return CreatePredictor(config);
 }


### PR DESCRIPTION
fix ernie test for varlen api: EnableTensorRtOSS() -> EnableVarseqlen()