### PR TITLE
【Paddle-TensorRT】 Fix pir-trt document

### DIFF
--- a/docs-official/api_reference/python_api_doc/python_api_index.rst
+++ b/docs-official/api_reference/python_api_doc/python_api_index.rst
@@ -10,3 +10,4 @@ Python API 文档
     PredictorPool.md
     Tensor.md
     Enum.md
+    Paddle-TensorRT_interface.md


### PR DESCRIPTION
修复Paddle-TensorRT_interface在官网不显示